### PR TITLE
Patch renv GitHub bug

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -179,6 +179,12 @@
   access top the lists of translated strings. These have replaced the `tr_()`
   strings at the point of generation.
 
+## BUG FIX
+
+* `manage_deps()` can now provision a GitHub package from the lockfile if it was
+  not previously installed on the system (reported: @pratikunterwegs,
+  carpentries/actions#32; fixed: @zkamvar, #533)
+
 # sandpaper 0.16.1 (2023-12-14)
 
 ## BUG FIX

--- a/R/utils-renv.R
+++ b/R/utils-renv.R
@@ -251,6 +251,12 @@ callr_manage_deps <- function(path, repos, snapshot, lockfile_exists) {
     deps <- unique(renv::dependencies(path = path, root = path, dev = TRUE)$Package)
     pkgs <- setdiff(deps, installed)
     needs_hydration <- length(pkgs) > 0
+    if (packageVersion("renv") >= "1.0.0") {
+      # We only need to hydrate the packages that do not exist in the lockfile
+      # and that are not installed
+      lock <- renv::lockfile_read(renv_lock)
+      pkgs <- setdiff(pkgs, names(lock$Packages))
+    }
   } else {
     # If there is not a lockfile, we need to run a fully hydration
     pkgs <- NULL


### PR DESCRIPTION
This PR is not intended to be merged. We are instead waiting for https://github.com/carpentries/sandpaper/pull/533 to be merged upstream directly.

We keep rebasing `patch-renv-github-bug` on `main` in our fork until it is merged upstream to be able to benefit from the latest sandpaper features while having this patch.
